### PR TITLE
Honest Benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,29 +1,37 @@
 benchmarks
 ==========
 
-**2016-04-21** Latest results, using `Node.js@4` and latest versions of modules:
+**2016-05-07** Latest results, using `Node.js@4` and latest versions of modules:
 
 * `enb@0.15.0`
 * `scan-level@0.0.4`
 
 ```
-         flat level
-bem-walk x 14,688 ops/sec ±2.08% (75 runs sampled) mean 0.07 ms
-     enb x 10,323 ops/sec ±1.36% (78 runs sampled) mean 0.10 ms
-   scanl x 12,016 ops/sec ±2.38% (78 runs sampled) mean 0.08 ms
+                         flat level
+                bem-walk x 13,091 ops/sec ±7.22% (70 runs sampled) mean 0.08 ms
+    bem-walk + fs.stat() x 5,169 ops/sec ±3.20% (69 runs sampled) mean 0.19 ms
+bem-walk + fs.statSync() x 9,522 ops/sec ±3.43% (78 runs sampled) mean 0.11 ms
+                     enb x 10,469 ops/sec ±1.89% (79 runs sampled) mean 0.10 ms
+                   scanl x 10,646 ops/sec ±6.66% (68 runs sampled) mean 0.09 ms
 
-         nested level
-bem-walk x 4,042 ops/sec ±2.25% (71 runs sampled) mean 0.25 ms
-     enb x 5,682 ops/sec ±3.61% (73 runs sampled) mean 0.18 ms
-   scanl x 4,412 ops/sec ±2.63% (73 runs sampled) mean 0.23 ms
+                         nested level
+                bem-walk x 3,693 ops/sec ±2.78% (71 runs sampled) mean 0.27 ms
+    bem-walk + fs.stat() x 2,511 ops/sec ±3.92% (68 runs sampled) mean 0.40 ms
+bem-walk + fs.statSync() x 3,392 ops/sec ±3.21% (74 runs sampled) mean 0.29 ms
+                     enb x 6,762 ops/sec ±1.50% (82 runs sampled) mean 0.15 ms
+                   scanl x 4,355 ops/sec ±4.11% (73 runs sampled) mean 0.23 ms
 
-         bem-bl
-bem-walk x 221 ops/sec ±3.87% (70 runs sampled) mean 4.53 ms
-     enb x 145 ops/sec ±1.77% (73 runs sampled) mean 6.92 ms
-   scanl x 131 ops/sec ±3.02% (73 runs sampled) mean 7.65 ms
+                         bem-bl
+                bem-walk x 195 ops/sec ±4.01% (67 runs sampled) mean 5.12 ms
+    bem-walk + fs.stat() x 106 ops/sec ±3.09% (69 runs sampled) mean 9.42 ms
+bem-walk + fs.statSync() x 145 ops/sec ±2.30% (75 runs sampled) mean 6.89 ms
+                     enb x 164 ops/sec ±2.74% (82 runs sampled) mean 6.12 ms
+                   scanl x 139 ops/sec ±3.18% (78 runs sampled) mean 7.22 ms
 
-         bem-components
-bem-walk x 143 ops/sec ±2.46% (72 runs sampled) mean 6.99 ms
-     enb x 83.64 ops/sec ±2.53% (75 runs sampled) mean 11.96 ms
-   scanl x 66.83 ops/sec ±7.89% (62 runs sampled) mean 14.96 ms
+                         bem-components
+                bem-walk x 139 ops/sec ±3.29% (72 runs sampled) mean 7.20 ms
+    bem-walk + fs.stat() x 60.70 ops/sec ±2.77% (69 runs sampled) mean 16.48 ms
+bem-walk + fs.statSync() x 85.82 ops/sec ±2.44% (77 runs sampled) mean 11.65 ms
+                     enb x 93.10 ops/sec ±1.67% (71 runs sampled) mean 10.74 ms
+                   scanl x 82.47 ops/sec ±2.79% (74 runs sampled) mean 12.13 ms
 ```

--- a/bench/run.js
+++ b/bench/run.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const fs = require('fs');
+const stream = require('stream');
+
 const Benchmark = require('Benchmark');
 const series = require('promise-map-series');
+const stringifyEntity = require('bem-naming').stringify;
 
 const fixtures = require('./fixtures');
 
@@ -21,18 +25,57 @@ series(cases, item => {
         const suite = new Benchmark.Suite(item.name);
 
         suite
-            .add('bem-walk', deferred => {
+            .add('                bem-walk', deferred => {
                 walk(item.levels, { defaults: { scheme: item.scheme } })
                     .resume().on('end', () => deferred.resolve());
             }, { defer: true })
-            .add('     enb', deferred => {
+            .add('    bem-walk + fs.stat()', deferred => {
+                const data = {};
+
+                walk(item.levels, { defaults: { scheme: item.scheme } })
+                    .pipe(new stream.Writable({
+                        objectMode: true,
+                        write: function (file, encoding, callback) {
+                            fs.stat(file.path, (err, stats) => {
+                                if (err) {
+                                    return callback(err);
+                                }
+
+                                const id = stringifyEntity(file.entity);
+
+                                file.stat = stats;
+                                data[id] = file;
+
+                                callback();
+                            });
+                        }
+                    }))
+                    .on('error', err => deferred.reject(err))
+                    .on('finish', () => deferred.resolve());
+            }, { defer: true })
+            .add('bem-walk + fs.statSync()', deferred => {
+                const data = {};
+
+                walk(item.levels, { defaults: { scheme: item.scheme } })
+                    .on('data', file => {
+                        const id = stringifyEntity(file.entity);
+                        const stats = fs.statSync(file.path);
+
+                        file.stat = stats;
+                        data[id] = file;
+                    })
+                    .resume()
+                    .on('error', err => deferred.reject(err))
+                    .on('end', () => deferred.resolve());
+            }, { defer: true })
+            .add('                     enb', deferred => {
                 enb(item.levels, item.scheme, () => deferred.resolve());
             }, { defer: true })
-            .add('   scanl', deferred => {
+            .add('                   scanl', deferred => {
                 scanl(item.levels, item.scheme, () => deferred.resolve());
             }, { defer: true })
             .on('start', () => {
-                console.log('         ' + item.name)
+                console.log('                         ' + item.name)
             })
             .on('cycle', event => {
                 const target = event.target;


### PR DESCRIPTION
The ENB and `scan-level` add `mtime` to file info (used `fs.statSync()`).

To comparison was honest need run `fs.statSync()` for each file.

```
                         flat level
                bem-walk x 13,091 ops/sec ±7.22% (70 runs sampled) mean 0.08 ms
    bem-walk + fs.stat() x 5,169 ops/sec ±3.20% (69 runs sampled) mean 0.19 ms
bem-walk + fs.statSync() x 9,522 ops/sec ±3.43% (78 runs sampled) mean 0.11 ms
                     enb x 10,469 ops/sec ±1.89% (79 runs sampled) mean 0.10 ms
                   scanl x 10,646 ops/sec ±6.66% (68 runs sampled) mean 0.09 ms

                         nested level
                bem-walk x 3,693 ops/sec ±2.78% (71 runs sampled) mean 0.27 ms
    bem-walk + fs.stat() x 2,511 ops/sec ±3.92% (68 runs sampled) mean 0.40 ms
bem-walk + fs.statSync() x 3,392 ops/sec ±3.21% (74 runs sampled) mean 0.29 ms
                     enb x 6,762 ops/sec ±1.50% (82 runs sampled) mean 0.15 ms
                   scanl x 4,355 ops/sec ±4.11% (73 runs sampled) mean 0.23 ms

                         bem-bl
                bem-walk x 195 ops/sec ±4.01% (67 runs sampled) mean 5.12 ms
    bem-walk + fs.stat() x 106 ops/sec ±3.09% (69 runs sampled) mean 9.42 ms
bem-walk + fs.statSync() x 145 ops/sec ±2.30% (75 runs sampled) mean 6.89 ms
                     enb x 164 ops/sec ±2.74% (82 runs sampled) mean 6.12 ms
                   scanl x 139 ops/sec ±3.18% (78 runs sampled) mean 7.22 ms

                         bem-components
                bem-walk x 139 ops/sec ±3.29% (72 runs sampled) mean 7.20 ms
    bem-walk + fs.stat() x 60.70 ops/sec ±2.77% (69 runs sampled) mean 16.48 ms
bem-walk + fs.statSync() x 85.82 ops/sec ±2.44% (77 runs sampled) mean 11.65 ms
                     enb x 93.10 ops/sec ±1.67% (71 runs sampled) mean 10.74 ms
                   scanl x 82.47 ops/sec ±2.79% (74 runs sampled) mean 12.13 ms
```